### PR TITLE
fix: remove vertical shift of the task text upon switching to edit mode

### DIFF
--- a/style.css
+++ b/style.css
@@ -94,7 +94,7 @@
 .task-input-title {
   margin: 0;
   font-size: 18px;
-  line-height: 21px;
+  line-height: 18px;
   height: 21px;
   padding: 0 9px;
   border: 1px solid #ddd;
@@ -143,6 +143,8 @@
   height: 2em;
   transform: rotateZ(45deg);
   transition: transform 200ms ease-in;
+  display: block;
+  width: 100%;
 }
 .btn__icon_delete-task:hover {
   transform: rotateZ(0);


### PR DESCRIPTION
for Deploy. fix: remove the vertical shift of the task title text upon switching to edit mode